### PR TITLE
Make AddKeyUp handle VirtualKeyCode.NUMPAD_RETURN correctly.

### DIFF
--- a/src/GregsStack.InputSimulatorStandard/GregsStack.InputSimulatorStandard.csproj
+++ b/src/GregsStack.InputSimulatorStandard/GregsStack.InputSimulatorStandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
     <Title>Input Simulator Standard</Title>
     <Authors>Michael Noonan, Theodoros Chatzigiannakis, Gregor Sindl</Authors>
     <Copyright>Copyright 2009-2019</Copyright>

--- a/src/GregsStack.InputSimulatorStandard/InputBuilder.cs
+++ b/src/GregsStack.InputSimulatorStandard/InputBuilder.cs
@@ -106,15 +106,15 @@
                     Type = (uint)InputType.Keyboard,
                     Data =
                             {
-                            Keyboard =
-                                new KeyboardInput
-                                    {
-                                        KeyCode = (ushort) code ,
-                                        Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
-                                        Flags = IsExtendedKey(keyCode) ? (uint) KeyboardFlag.ExtendedKey : 0,
-                                        Time = 0,
-                                        ExtraInfo = IntPtr.Zero
-                                    }
+                                Keyboard =
+                                    new KeyboardInput
+                                        {
+                                            KeyCode = (ushort) code ,
+                                            Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
+                                            Flags = IsExtendedKey(keyCode) ? (uint) KeyboardFlag.ExtendedKey : 0,
+                                            Time = 0,
+                                            ExtraInfo = IntPtr.Zero
+                                        }
                             }
                 };
 

--- a/src/GregsStack.InputSimulatorStandard/InputBuilder.cs
+++ b/src/GregsStack.InputSimulatorStandard/InputBuilder.cs
@@ -106,15 +106,15 @@
                     Type = (uint)InputType.Keyboard,
                     Data =
                             {
-                                Keyboard =
-                                    new KeyboardInput
-                                        {
-                                            KeyCode = (ushort) code ,
-                                            Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
-                                            Flags = IsExtendedKey(keyCode) ? (uint) KeyboardFlag.ExtendedKey : 0,
-                                            Time = 0,
-                                            ExtraInfo = IntPtr.Zero
-                                        }
+                            Keyboard =
+                                new KeyboardInput
+                                    {
+                                        KeyCode = (ushort) code ,
+                                        Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
+                                        Flags = IsExtendedKey(keyCode) ? (uint) KeyboardFlag.ExtendedKey : 0,
+                                        Time = 0,
+                                        ExtraInfo = IntPtr.Zero
+                                    }
                             }
                 };
 
@@ -129,6 +129,7 @@
         /// <returns>This <see cref="InputBuilder"/> instance.</returns>
         public InputBuilder AddKeyUp(VirtualKeyCode keyCode)
         {
+            var code = (ushort)((int)keyCode & 0xFFFF);
             var up =
                 new Input
                 {
@@ -138,8 +139,8 @@
                                 Keyboard =
                                     new KeyboardInput
                                         {
-                                            KeyCode = (ushort) keyCode,
-                                            Scan = (ushort)(NativeMethods.MapVirtualKey((uint)keyCode, 0) & 0xFFU),
+                                            KeyCode = (ushort) code,
+                                            Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
                                             Flags = (uint) (IsExtendedKey(keyCode)
                                                                   ? KeyboardFlag.KeyUp | KeyboardFlag.ExtendedKey
                                                                   : KeyboardFlag.KeyUp),

--- a/tests/GregsStack.InputSimulatorStandard.Tests/GregsStack.InputSimulatorStandard.Tests.csproj
+++ b/tests/GregsStack.InputSimulatorStandard.Tests/GregsStack.InputSimulatorStandard.Tests.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,10 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\GregsStack.InputSimulatorStandard\GregsStack.InputSimulatorStandard.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Key up for this extended key code was not working with at least one target app (the game Elite Dangerous). This change makes AddKeyUp work like AddKeyDown, and that fixed the issue.