### PR TITLE
Make AddKeyUp handle VirtualKeyCode.NUMPAD_RETURN correctly.

### DIFF
--- a/src/GregsStack.InputSimulatorStandard/InputBuilder.cs
+++ b/src/GregsStack.InputSimulatorStandard/InputBuilder.cs
@@ -106,15 +106,15 @@
                     Type = (uint)InputType.Keyboard,
                     Data =
                             {
-                            Keyboard =
-                                new KeyboardInput
-                                    {
-                                        KeyCode = (ushort) code ,
-                                        Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
-                                        Flags = IsExtendedKey(keyCode) ? (uint) KeyboardFlag.ExtendedKey : 0,
-                                        Time = 0,
-                                        ExtraInfo = IntPtr.Zero
-                                    }
+                                Keyboard =
+                                    new KeyboardInput
+                                        {
+                                            KeyCode = (ushort) code ,
+                                            Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
+                                            Flags = IsExtendedKey(keyCode) ? (uint) KeyboardFlag.ExtendedKey : 0,
+                                            Time = 0,
+                                            ExtraInfo = IntPtr.Zero
+                                        }
                             }
                 };
 

--- a/src/GregsStack.InputSimulatorStandard/InputBuilder.cs
+++ b/src/GregsStack.InputSimulatorStandard/InputBuilder.cs
@@ -106,15 +106,15 @@
                     Type = (uint)InputType.Keyboard,
                     Data =
                             {
-                                Keyboard =
-                                    new KeyboardInput
-                                        {
-                                            KeyCode = (ushort) code ,
-                                            Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
-                                            Flags = IsExtendedKey(keyCode) ? (uint) KeyboardFlag.ExtendedKey : 0,
-                                            Time = 0,
-                                            ExtraInfo = IntPtr.Zero
-                                        }
+                            Keyboard =
+                                new KeyboardInput
+                                    {
+                                        KeyCode = (ushort) code ,
+                                        Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
+                                        Flags = IsExtendedKey(keyCode) ? (uint) KeyboardFlag.ExtendedKey : 0,
+                                        Time = 0,
+                                        ExtraInfo = IntPtr.Zero
+                                    }
                             }
                 };
 
@@ -129,6 +129,7 @@
         /// <returns>This <see cref="InputBuilder"/> instance.</returns>
         public InputBuilder AddKeyUp(VirtualKeyCode keyCode)
         {
+            var code = (ushort)((int)keyCode & 0xFFFF);
             var up =
                 new Input
                 {
@@ -138,8 +139,8 @@
                                 Keyboard =
                                     new KeyboardInput
                                         {
-                                            KeyCode = (ushort) keyCode,
-                                            Scan = (ushort)(NativeMethods.MapVirtualKey((uint)keyCode, 0) & 0xFFU),
+                                            KeyCode = (ushort) code,
+                                            Scan = (ushort)(NativeMethods.MapVirtualKey((uint)code, 0) & 0xFFU),
                                             Flags = (uint) (IsExtendedKey(keyCode)
                                                                   ? KeyboardFlag.KeyUp | KeyboardFlag.ExtendedKey
                                                                   : KeyboardFlag.KeyUp),


### PR DESCRIPTION
Key up for this extended key code was not working with at least one target app (the game Elite Dangerous). This change makes AddKeyUp work like AddKeyDown, and that fixed the issue.